### PR TITLE
Gagazet logic change and fix broken ref on world map

### DIFF
--- a/locations/Spira.json
+++ b/locations/Spira.json
@@ -2597,15 +2597,15 @@
                     },
                     {
                         "name": "Press Both Glyphs, Then Take Narrow Central Path (Chest)",
-                        "ref": "Omega Ruins/Press Both Glyphs, Then Take Narrow Central Path (Chest)/Teleport Sphere x1"
+                        "ref": "Omega Ruins/Ultima/Press Both Glyphs, Then Take Narrow Central Path (Chest)/Teleport Sphere x1"
                     },
                     {
                         "name": "Defeat Ultima Weapon (Boss)",
-                        "ref": "Omega Ruins/Defeat Ultima Weapon (Boss)/Ultima Weapon"
+                        "ref": "Omega Ruins/Ultima/Defeat Ultima Weapon (Boss)/Ultima Weapon"
                     },
                     {
                         "name": "West Path (Chest)",
-                        "ref": "Omega Ruins/West Path (Chest)/Friend Sphere x1"
+                        "ref": "Omega Ruins/Omega/West Path (Chest)/Friend Sphere x1"
                     },
                     {
                         "name": "Use Lancet to Learn Nova\nOmega Weapon", 
@@ -2617,7 +2617,7 @@
                     },
                     {
                         "name": "Omega Boss Arena (Chest)",
-                        "ref": "Omega Ruins/Omega Boss Arena (Chest)/Magic Sphere x1"
+                        "ref": "Omega Ruins/Omega/Omega Boss Arena (Chest)/Magic Sphere x1"
                     }
                 ]
             },

--- a/locations/Spira.json
+++ b/locations/Spira.json
@@ -2359,7 +2359,7 @@
                     },
                     {
                         "name": "Trail - Side Road (Braska's Sphere)",
-                        "ref": "Mt. Gagazet/Outside/Trail - Side Road (Braska's Sphere)/Progressive Jecht's Sphere"
+                        "ref": "Jecht's Spheres/Trail - Side Road (Braska's Sphere)/Progressive Jecht's Sphere"
                     },
                     {
                         "name": "Trail - West Branch Before Bridge to Wantz (Chest)",

--- a/locations/generic/Jecht's Spheres.json
+++ b/locations/generic/Jecht's Spheres.json
@@ -72,7 +72,7 @@
             },
             {
                 "name": "Trail - Side Road (Braska's Sphere)",
-                "access_rules": ["@Mt. Gagazet, $hasKimahri"],
+                "access_rules": ["@Mt. Gagazet, biran, yenke"],
                 "hosted_item": "braskasphere",
                 "clear_as_group": true,
                 "sections": [{"name": "Progressive Jecht's Sphere"}]

--- a/locations/generic/Jecht's Spheres.json
+++ b/locations/generic/Jecht's Spheres.json
@@ -72,7 +72,7 @@
             },
             {
                 "name": "Trail - Side Road (Braska's Sphere)",
-                "access_rules": ["@Mt. Gagazet, biran, yenke, [$hasMinimumParty|3]"],
+                "access_rules": ["@Mt. Gagazet, $hasKimahri"],
                 "hosted_item": "braskasphere",
                 "clear_as_group": true,
                 "sections": [{"name": "Progressive Jecht's Sphere"}]

--- a/locations/regions/Mt. Gagazet.json
+++ b/locations/regions/Mt. Gagazet.json
@@ -23,6 +23,7 @@
             },
             {
                 "name": "Outside",
+                "access_rules": ["biran, yenke"],
                 "children": [
                     {
                         "name": "Trail - Top of Right Ridge Near South Exit (Chest)",

--- a/locations/regions/Mt. Gagazet.json
+++ b/locations/regions/Mt. Gagazet.json
@@ -4,12 +4,11 @@
         "chest_unopened_img": "/images/Treasure.png",
         "chest_opened_img": "/images/TreasureBW.png",
         "overlay_background": "#000000",
-        "access_rules": ["^$CheckAccessLevel|gagazet"],
+        "access_rules": ["^$CheckAccessLevel|gagazet, $hasKimahri"],
         "children": [
             {
                 "name": "Defeat Biran and Yenke (Boss)",
                 "map_locations": [{ "map": "Gagazet Outside", "x": 772, "y": 390, "shape": "trapezoid", "size": 24}],
-                "access_rules": ["$hasKimahri"],
                 "sections": [
                     {"name": "Biran and Yenke", "hosted_item": "biran, yenke", "clear_as_group": true},
                     {"name": "Use Lancet to Learn Thrust Kick\nBiran", "ref": "Overdrives/Ronso Rage/Use Lancet to Learn Thrust Kick/MTGZ Thrust Kick"},
@@ -24,7 +23,6 @@
             },
             {
                 "name": "Outside",
-                "access_rules": ["biran, yenke"],
                 "children": [
                     {
                         "name": "Trail - Top of Right Ridge Near South Exit (Chest)",


### PR DESCRIPTION
Changed all locations in gagazet to only look for kimahri instead of B + Y

Fixed Braska Sphere ref on world map