### PR TITLE
Area Conquest Reward access rule update

### DIFF
--- a/locations/monster arena/Monster Arena.json
+++ b/locations/monster arena/Monster Arena.json
@@ -1340,7 +1340,7 @@
                             },
                             {
                                 "name": "Macalania",
-                                "access_rules": ["^$CheckAccessLevel|macalania, snowwolf:1, iguion:1, wasp:1, evileye:1, iceflan:1, blueelement:1, murussu:1, mafdet:1, xiphos:1, chimera:1"],
+                                "access_rules": ["^$CheckAccessLevel|macalania, snowwolf:1, iguion:1, wasp:1, evileye:1, iceflan:1, blueelement:1, murussu:1, mafdet:1, xiphos:1, chimera:1, [$hasMinimumParty|3]"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
@@ -1368,7 +1368,7 @@
                             },
                             {
                                 "name": "Mt. Gagazet",
-                                "access_rules": ["^$CheckAccessLevel|mtgagazet, bandersnatch:1, ahriman:1, darkflan:1, grenade:1, grat:1, grendel:1, bashura:1, mandragora:1, behemoth:1, splasher:1, achelous:1, maelspike:1, [$hasMinimumParty|3]"],
+                                "access_rules": ["^$CheckAccessLevel|gagazet, bandersnatch:1, ahriman:1, darkflan:1, grenade:1, grat:1, grendel:1, bashura:1, mandragora:1, behemoth:1, splasher:1, achelous:1, maelspike:1, [$hasMinimumParty|3]"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
@@ -1382,7 +1382,7 @@
                             },
                             {
                                 "name": "Omega Dungeon",
-                                "access_rules": ["^$CheckAccessLevel|omegadungeon, zaurus:1, floatingdeath:1, blackelement:1, halma:1, puroboros:1, spirit:1, machea:1, mastercoeurl:1, mastertonberry:1, varuna:1"],
+                                "access_rules": ["^$CheckAccessLevel|omegaruins, zaurus:1, floatingdeath:1, blackelement:1, halma:1, puroboros:1, spirit:1, machea:1, mastercoeurl:1, mastertonberry:1, varuna:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true

--- a/locations/monster arena/Monster Arena.json
+++ b/locations/monster arena/Monster Arena.json
@@ -1319,70 +1319,70 @@
                             },
                             {
                                 "name": "Mushroom Rock Road",
-                                "access_rules": ["^$CheckAccessLevel|mushroomrockroad, raptor:1, gandarewa:1, thunderflan:1, redelement:1, lamashtu:1, funguar:1, garuda:1"],
+                                "access_rules": ["@Mushroom Rock Road, raptor:1, gandarewa:1, thunderflan:1, redelement:1, lamashtu:1, funguar:1, garuda:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Djose Road",
-                                "access_rules": ["^$CheckAccessLevel|djose, garm:1, simurgh:1, bitebug:1, snowflan:1, bunyip:1, basilisk:1, ochu:1"],
+                                "access_rules": ["@Djose, @Moonflow, garm:1, simurgh:1, bitebug:1, snowflan:1, bunyip:1, basilisk:1, ochu:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Thunder Plains",
-                                "access_rules": ["^$CheckAccessLevel|thunderplains, melusine:1, aerouge:1, buer:1, goldelement:1, kusariqqu:1, larva:1, irongiant:1, qactuar:1"],
+                                "access_rules": ["@Thunder Plains, melusine:1, aerouge:1, buer:1, goldelement:1, kusariqqu:1, larva:1, irongiant:1, qactuar:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Macalania",
-                                "access_rules": ["^$CheckAccessLevel|macalania, snowwolf:1, iguion:1, wasp:1, evileye:1, iceflan:1, blueelement:1, murussu:1, mafdet:1, xiphos:1, chimera:1, [$hasMinimumParty|3]"],
+                                "access_rules": ["@Macalania/Lake, snowwolf:1, iguion:1, wasp:1, evileye:1, iceflan:1, blueelement:1, murussu:1, mafdet:1, xiphos:1, chimera:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Bikanel",
-                                "access_rules": ["^$CheckAccessLevel|bikanel, sandwolf:1, alcyone:1, mushussu:1, zu:1, sandworm:1, cactuar:1"],
+                                "access_rules": ["@Bikanel, sandwolf:1, alcyone:1, mushussu:1, zu:1, sandworm:1, cactuar:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Calm Lands",
-                                "access_rules": ["^$CheckAccessLevel|calmlands, skoll:1, nebiros:1, flameflan:1, shred:1, anacondaur:1, ogre:1, coeurl:1, chimerabrain:1, malboro:1"],
+                                "access_rules": ["@Calm Lands, skoll:1, nebiros:1, flameflan:1, shred:1, anacondaur:1, ogre:1, coeurl:1, chimerabrain:1, malboro:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Stolen Fayth Cavern",
-                                "access_rules": ["^$CheckAccessLevel|cavernofthestolenfayth, yowie: 1, imp:1, darkelement:1, nidhogg:1, thorn:1, valaha:1, epaaj:1, ghost:1, tonberry:1"],
+                                "access_rules": ["@Cavern of the Stolen Fayth, yowie: 1, imp:1, darkelement:1, nidhogg:1, thorn:1, valaha:1, epaaj:1, ghost:1, tonberry:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Mt. Gagazet",
-                                "access_rules": ["^$CheckAccessLevel|gagazet, bandersnatch:1, ahriman:1, darkflan:1, grenade:1, grat:1, grendel:1, bashura:1, mandragora:1, behemoth:1, splasher:1, achelous:1, maelspike:1, [$hasMinimumParty|3]"],
+                                "access_rules": ["@Mt. Gagazet/Inside, bandersnatch:1, ahriman:1, darkflan:1, grenade:1, grat:1, grendel:1, bashura:1, mandragora:1, behemoth:1, splasher:1, achelous:1, maelspike:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Inside Sin",
-                                "access_rules": ["^$CheckAccessLevel|sin, exoray:1, wraith:1, geminisword:1, geminiclub:1, demonolith:1, greatmalboro:1, barbatos:1, adamantoise:1, behemothking:1, [$hasMinimumParty|3]"],
+                                "access_rules": ["@Inside Sin/City of Dying Dreams, exoray:1, wraith:1, geminisword:1, geminiclub:1, demonolith:1, greatmalboro:1, barbatos:1, adamantoise:1, behemothking:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Omega Dungeon",
-                                "access_rules": ["^$CheckAccessLevel|omegaruins, zaurus:1, floatingdeath:1, blackelement:1, halma:1, puroboros:1, spirit:1, machea:1, mastercoeurl:1, mastertonberry:1, varuna:1"],
+                                "access_rules": ["@Omega Ruins, zaurus:1, floatingdeath:1, blackelement:1, halma:1, puroboros:1, spirit:1, machea:1, mastercoeurl:1, mastertonberry:1, varuna:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true

--- a/locations/monster arena/Monster Arena.json
+++ b/locations/monster arena/Monster Arena.json
@@ -1312,7 +1312,7 @@
                             },
                             {
                                 "name": "Miihen Highroad",
-                                "access_rules": ["^$CheckAccessLevel|miihenhighroad, miihenfang:1, ipiria:1, floatingeye:1, whiteelement:1, raldo:1, vouivre:1, bomb:1, dualhorn:1, [$hasMinimumParty|3]"],
+                                "access_rules": ["@Miihen Highroad/North, miihenfang:1, ipiria:1, floatingeye:1, whiteelement:1, raldo:1, vouivre:1, bomb:1, dualhorn:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true

--- a/locations/monster arena/Monster Arena.json
+++ b/locations/monster arena/Monster Arena.json
@@ -1312,77 +1312,77 @@
                             },
                             {
                                 "name": "Miihen Highroad",
-                                "access_rules": ["miihenfang:1, ipiria:1, floatingeye:1, whiteelement:1, raldo:1, vouivre:1, bomb:1, dualhorn:1"],
+                                "access_rules": ["^$CheckAccessLevel|miihenhighroad, miihenfang:1, ipiria:1, floatingeye:1, whiteelement:1, raldo:1, vouivre:1, bomb:1, dualhorn:1, [$hasMinimumParty|3]"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Mushroom Rock Road",
-                                "access_rules": ["raptor:1, gandarewa:1, thunderflan:1, redelement:1, lamashtu:1, funguar:1, garuda:1"],
+                                "access_rules": ["^$CheckAccessLevel|mushroomrockroad, raptor:1, gandarewa:1, thunderflan:1, redelement:1, lamashtu:1, funguar:1, garuda:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Djose Road",
-                                "access_rules": ["garm:1, simurgh:1, bitebug:1, snowflan:1, bunyip:1, basilisk:1, ochu:1"],
+                                "access_rules": ["^$CheckAccessLevel|djose, garm:1, simurgh:1, bitebug:1, snowflan:1, bunyip:1, basilisk:1, ochu:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Thunder Plains",
-                                "access_rules": ["melusine:1, aerouge:1, buer:1, goldelement:1, kusariqqu:1, larva:1, irongiant:1, qactuar:1"],
+                                "access_rules": ["^$CheckAccessLevel|thunderplains, melusine:1, aerouge:1, buer:1, goldelement:1, kusariqqu:1, larva:1, irongiant:1, qactuar:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Macalania",
-                                "access_rules": ["snowwolf:1, iguion:1, wasp:1, evileye:1, iceflan:1, blueelement:1, murussu:1, mafdet:1, xiphos:1, chimera:1"],
+                                "access_rules": ["^$CheckAccessLevel|macalania, snowwolf:1, iguion:1, wasp:1, evileye:1, iceflan:1, blueelement:1, murussu:1, mafdet:1, xiphos:1, chimera:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Bikanel",
-                                "access_rules": ["sandwolf:1, alcyone:1, mushussu:1, zu:1, sandworm:1, cactuar:1"],
+                                "access_rules": ["^$CheckAccessLevel|bikanel, sandwolf:1, alcyone:1, mushussu:1, zu:1, sandworm:1, cactuar:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Calm Lands",
-                                "access_rules": ["skoll:1, nebiros:1, flameflan:1, shred:1, anacondaur:1, ogre:1, coeurl:1, chimerabrain:1, malboro:1"],
+                                "access_rules": ["^$CheckAccessLevel|calmlands, skoll:1, nebiros:1, flameflan:1, shred:1, anacondaur:1, ogre:1, coeurl:1, chimerabrain:1, malboro:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Stolen Fayth Cavern",
-                                "access_rules": ["yowie: 1, imp:1, darkelement:1, nidhogg:1, thorn:1, valaha:1, epaaj:1, ghost:1, tonberry:1"],
+                                "access_rules": ["^$CheckAccessLevel|cavernofthestolenfayth, yowie: 1, imp:1, darkelement:1, nidhogg:1, thorn:1, valaha:1, epaaj:1, ghost:1, tonberry:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Mt. Gagazet",
-                                "access_rules": ["bandersnatch:1, ahriman:1, darkflan:1, grenade:1, grat:1, grendel:1, bashura:1, mandragora:1, behemoth:1, splasher:1, achelous:1, maelspike:1"],
+                                "access_rules": ["^$CheckAccessLevel|mtgagazet, bandersnatch:1, ahriman:1, darkflan:1, grenade:1, grat:1, grendel:1, bashura:1, mandragora:1, behemoth:1, splasher:1, achelous:1, maelspike:1, [$hasMinimumParty|3]"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Inside Sin",
-                                "access_rules": ["exoray:1, wraith:1, geminisword:1, geminiclub:1, demonolith:1, greatmalboro:1, barbatos:1, adamantoise:1, behemothking:1"],
+                                "access_rules": ["^$CheckAccessLevel|sin, exoray:1, wraith:1, geminisword:1, geminiclub:1, demonolith:1, greatmalboro:1, barbatos:1, adamantoise:1, behemothking:1, [$hasMinimumParty|3]"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true
                             },
                             {
                                 "name": "Omega Dungeon",
-                                "access_rules": ["zaurus:1, floatingdeath:1, blackelement:1, halma:1, puroboros:1, spirit:1, machea:1, mastercoeurl:1, mastertonberry:1, varuna:1"],
+                                "access_rules": ["^$CheckAccessLevel|omegadungeon, zaurus:1, floatingdeath:1, blackelement:1, halma:1, puroboros:1, spirit:1, machea:1, mastercoeurl:1, mastertonberry:1, varuna:1"],
                                 "hosted_item": "areaconquests",
                                 "item_count": 1,
                                 "clear_as_group": true


### PR DESCRIPTION
updated access rules to prevent out of logic captures showing the conquest reward in logic